### PR TITLE
Fix: Resolve HTML tag mismatch error in App.jsx

### DIFF
--- a/Client/src/App.jsx
+++ b/Client/src/App.jsx
@@ -393,6 +393,7 @@ function App() {
           )}
         </div>
       </section>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fixed missing closing `</main>` tag in App.jsx that was causing build failures
- Build now passes successfully with all 197 modules transformed
- Resolves deployment error preventing Vercel builds

## Test plan
- [x] Verified build completes successfully with `npm run build`
- [x] Confirmed all components and assets compile properly
- [x] No syntax errors or tag mismatches remain

## Changes
- Added missing `</main>` closing tag at line 396 in App.jsx
- Maintains proper HTML structure: `<div>` → `<main>` → content → `</main>` → `</div>`